### PR TITLE
要素が画面幅を超えた場合にスクロールできない不具合を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
             justify-content: center;
             align-items: center;
             position: relative;
-            overflow: hidden;
         }
 
         .gradient-overlay {


### PR DESCRIPTION
## 概要
SP横持ちなどで要素が画面幅を超えた場合にスクロールできない不具合を修正しました。

## 不具合の原因

- 要素が画面幅を超えるとスクロールしないCSS（`overflow: hidden;`）が定義されていた

## 修正内容

- `overflow: hidden;`の指定を削除