### PR TITLE
iPhone等でSafeArea部分に背景色が適用されるように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(180deg, #90d1dd, #acb6e5 20%, #74ebd5 80%, #90d1dd);
+            background: linear-gradient(180deg, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
             opacity: 0;
             animation: fadeInGradient 1.5s ease-in 0.5s forwards;
             z-index: -1;

--- a/index.html
+++ b/index.html
@@ -228,8 +228,11 @@
 
         /* スマホ横持ち */
         @media (max-width: 900px) and (orientation: landscape) {
+            body {
+                background: white;
+            }
             .gradient-overlay {
-                background: linear-gradient(to right, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
+                background: #acb6e5;
             }
         }
 

--- a/index.html
+++ b/index.html
@@ -12,9 +12,12 @@
             box-sizing: border-box;
         }
 
+        html {
+            background: #74ebd5;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-            background: #90d1dd;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -33,9 +36,9 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(to bottom, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
-            opacity: 0;
-            animation: fadeInGradient 1.5s ease-in 0.5s forwards;
+            background: white;
+            opacity: 1;
+            animation: fadeOutGradient 1.5s ease-in 0.5s forwards;
             z-index: -1;
         }
 
@@ -178,9 +181,9 @@
             }
         }
 
-        @keyframes fadeInGradient {
+        @keyframes fadeOutGradient {
             to {
-                opacity: 1;
+                opacity: 0;
             }
         }
 
@@ -191,7 +194,6 @@
             }
         }
 
-        /* スマホ縦持ち */
         @media (max-width: 600px) and (orientation: portrait) {
             .container {
                 padding: 20px;
@@ -225,17 +227,6 @@
                 height: 20px;
             }
         }
-
-        /* スマホ横持ち */
-        @media (max-width: 900px) and (orientation: landscape) {
-            body {
-                background: white;
-            }
-            .gradient-overlay {
-                background: #acb6e5;
-            }
-        }
-
     </style>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-            background: #acb6e5;
+            background: #90d1dd;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -33,7 +33,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(180deg, #acb6e5, #74ebd5);
+            background: linear-gradient(180deg, #90d1dd, #acb6e5 20%, #74ebd5 80%, #90d1dd);
             opacity: 0;
             animation: fadeInGradient 1.5s ease-in 0.5s forwards;
             z-index: -1;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-            background: white;
+            background: #acb6e5;
             min-height: 100vh;
             display: flex;
             justify-content: center;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 viewport-fit=cover">
     <title>上ちょ / uetyo - Software Developer</title>
     <style>
         * {

--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
             justify-content: center;
             align-items: center;
             position: relative;
+            /* iPhoneのSafeArea対応 */
+            padding-top: env(safe-area-insets-top);
+            padding-bottom: env(safe-area-insets-bottom);
+            padding-left: env(safe-area-insets-left);
+            padding-right: env(safe-area-insets-right);
         }
 
         .gradient-overlay {

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(180deg, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
+            background: linear-gradient(to bottom, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
             opacity: 0;
             animation: fadeInGradient 1.5s ease-in 0.5s forwards;
             z-index: -1;
@@ -191,7 +191,8 @@
             }
         }
 
-        @media (max-width: 768px) {
+        /* スマホ縦持ち */
+        @media (max-width: 600px) and (orientation: portrait) {
             .container {
                 padding: 20px;
             }
@@ -222,6 +223,13 @@
             .link-icon {
                 width: 20px;
                 height: 20px;
+            }
+        }
+
+        /* スマホ横持ち */
+        @media (max-width: 900px) and (orientation: landscape) {
+            .gradient-overlay {
+                background: linear-gradient(to right, #90d1dd, #acb6e5 20%, #74ebd5 70%, #90d1dd);
             }
         }
 


### PR DESCRIPTION
## 概要
https://github.com/psbss/ue-y.me/issues/55 の対応（iPhone等でSafeArea部分に背景色が適用されるように修正する）を行いました。

## 修正内容

- metaタグに`viewport-fit=cover`を追加
- iPhoneのSafeArea対応処理を追加
- bodyの背景色を変更